### PR TITLE
feat: add odbc support for source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ description = "Framework to build ETL data pipelines declaratively"
 homepage = "https://github.com/vigimite/aqueducts"
 repository = "https://github.com/vigimite/aqueducts"
 readme = "README.md"
-version = "0.1.2"
+version = "0.2.0"
 keywords = ["aqueducts", "ETL", "data", "pipeline"]
 categories = ["api-bindings"]
 license-file = "LICENSE"
 
 [workspace.dependencies]
-aqueducts = { path = "aqueducts/core", version = "0.1.2" }
-aqueducts-utils = { path = "aqueducts/utils", version = "0.1.2" }
+aqueducts = { path = "aqueducts/core", version = "0.2.0" }
+aqueducts-utils = { path = "aqueducts/utils", version = "0.2.0" }
 
 datafusion = "37"
 object_store = "0.9"

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ This can be provided by an external `SessionContext` passed into the `run_pipeli
 An Aqueduct stage defines a transformation using SQL. Each stage has access to all defined sources and to every previously executed stage within the SQL context using the respectively configured names.
 Once executed the stage will then persist its result into the SQL context making it accessible to downstream consumers.
 
-The stage can be set to print the result and/or the result schema to the `stdout`. This is usefull for development/debugging purposes.
+The stage can be set to print the result and/or the result schema to the `stdout`. This is useful for development/debugging purposes.
 
 ### Destination
 

--- a/README.md
+++ b/README.md
@@ -166,12 +166,23 @@ An Aqueduct source can be:
   - single file
   - directory
 - Delta table
-- PostgreSQL table (NOT IMPLEMENTED YET)
+- ODBC query (EXPERIMENTAL)
 
 For file based sources a schema can be provided optionally.
 
 The source is registered within the `SessionContext` as a table that can be referenced using the sources configured name. A prerequisite here is that the necessary features for the underlying obejct stores are enabled.
 This can be provided by an external `SessionContext` passed into the `run_pipeline` function or by registering the correct handlers for deltalake.
+
+**EXPERIMENTAL ODBC support**
+
+As an experimental feature it is possible to query various databases using ODBC. This is enabled through [arrow-odbc](https://crates.io/crates/arrow-odbc).
+Besides enabling the `odbc` feature flag in your `Cargo.toml` there are some other prerequisites for the executing system:
+
+- `unixodbc` on unix based systems
+- ODBC driver for the database you want to access like [ODBC Driver for SQL server](https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server) or [psqlodbc](https://github.com/postgresql-interfaces/psqlodbc)
+- registering the driver in the ODBC manager configuration (usually located in `/etc/odbcinst.ini`)
+
+If you have issues setting this up there are many resources online explaining how to set this up, it is a bit of a hassle.
 
 ### Stage
 
@@ -188,14 +199,16 @@ An Aqueduct destination can be:
   - single file
   - directory
 - Delta table
-- PostgreSQL table (NOT IMPLEMENTED YET)
+- ODBC query (NOT IMPLEMENTED YET)
 
 An Aqueduct destination is the target for the execution of the pipeline, the result of the final stage that was executed is used as the input for the destination to write the data to the underlying table/file.
 
 **File based destinations**
+
 File based destinations have support for HDFS style partitioning (`output/location=1/...`) and can be set to output only a single file or multiple files based on the configuration.
 
 **Delta Table destination**
+
 For a DeltaTable there is some additional logic that is utilized to maintain the table integrity.
 
 The destination will first cast and validate the schema of the input data and then use one of 3 configurable modes to write the data:
@@ -209,6 +222,6 @@ The destination will first cast and validate the schema of the input data and th
 ## Roadmap
 
 - [ ] Docs
-- [ ] PostgreSQL source
-- [ ] PostgreSQL destination
+- [x] ODBC source
+- [ ] ODBC destination
 - [ ] Parallel processing of stages

--- a/aqueducts-cli/Cargo.toml
+++ b/aqueducts-cli/Cargo.toml
@@ -6,13 +6,13 @@ description = "CLI application to run pipelines defined for the aqueducts framew
 homepage = "https://github.com/vigimite/aqueducts"
 repository = "https://github.com/vigimite/aqueducts/aqueducts-cli"
 readme = "README.md"
-version = "0.1.2"
+version = "0.2.0"
 keywords = ["aqueducts", "ETL", "data", "pipeline", "cli"]
 categories = ["command-line-utilities"]
 license-file = "../LICENSE"
 
 [dependencies]
-aqueducts = { path = "../aqueducts/core", version = "0.1", features = ["s3", "gcs", "azure"] }
+aqueducts = { path = "../aqueducts/core", version = "0.2", features = ["s3", "gcs", "azure", "odbc"] }
 clap = { version = "4.5.4", features = ["derive"] }
 env_logger = "0.11.3"
 log = "0.4.21"

--- a/aqueducts/core/Cargo.toml
+++ b/aqueducts/core/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 s3 = ["aqueducts-utils/s3"]
 gcs = ["aqueducts-utils/gcs"]
 azure = ["aqueducts-utils/azure"]
+odbc = ["aqueducts-utils/odbc"]
 
 [dependencies]
 datafusion.workspace = true

--- a/aqueducts/core/src/destinations/delta.rs
+++ b/aqueducts/core/src/destinations/delta.rs
@@ -25,7 +25,7 @@ pub struct DeltaDestination {
     #[serde(default)]
     pub storage_options: HashMap<String, String>,
 
-    /// DeltaTable table properties: https://docs.delta.io/latest/table-properties.html
+    /// DeltaTable table properties: <https://docs.delta.io/latest/table-properties.html>
     pub table_properties: HashMap<String, Option<String>>,
 
     /// Columns that will be used to determine uniquness during merge operation

--- a/aqueducts/core/src/sources/error.rs
+++ b/aqueducts/core/src/sources/error.rs
@@ -1,5 +1,7 @@
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("To use ODBC type you need to enable the odbc feature")]
+    OdbcFeatureDisabled,
     // -- External
     #[error("ArrowError({0})")]
     ArrowError(#[from] datafusion::arrow::error::ArrowError),

--- a/aqueducts/utils/Cargo.toml
+++ b/aqueducts/utils/Cargo.toml
@@ -16,8 +16,10 @@ default = []
 s3 = ["dep:deltalake-aws"]
 gcs = ["dep:deltalake-gcp"]
 azure = ["dep:deltalake-azure"]
+odbc = ["dep:arrow-odbc"]
 
 [dependencies]
+datafusion.workspace = true
 deltalake.workspace = true
 url.workspace = true
 serde.workspace = true
@@ -26,3 +28,10 @@ thiserror.workspace = true
 deltalake-aws = { version = "0.1", optional = true }
 deltalake-gcp = { version = "0.2", optional = true }
 deltalake-azure = { version = "0.1", optional = true }
+arrow-odbc = { version = "11.0.0", optional = true }
+object_store = "0.9"
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+tracing-test = "0.2"

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,10 @@
+CREATE TABLE temp_readings (
+    location_id INTEGER,
+    timestamp TIMESTAMP,
+    temperature_c FLOAT,
+    humidity FLOAT,
+    weather_condition VARCHAR(50)
+);
+
+COPY temp_readings FROM '/data/temp_readings_jan_2024.csv' DELIMITER ',' CSV HEADER;
+COPY temp_readings FROM '/data/temp_readings_feb_2024.csv' DELIMITER ',' CSV HEADER;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+
+services:
+
+  db:
+    image: postgres:15
+    restart: no
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - 5432:5432
+    volumes:
+      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./examples/temp_readings_jan_2024.csv:/data/temp_readings_jan_2024.csv
+      - ./examples/temp_readings_feb_2024.csv:/data/temp_readings_feb_2024.csv

--- a/examples/aqueduct_pipeline_odbc.yml
+++ b/examples/aqueduct_pipeline_odbc.yml
@@ -1,0 +1,50 @@
+sources:
+  - type: Odbc
+    name: jan_data
+    connection_string: Driver={PostgreSQL Unicode};Server=localhost;UID=${user};PWD=${pass};
+    query: SELECT * FROM temp_readings WHERE timestamp BETWEEN '2024-01-01' AND '2024-01-31'
+
+  - type: Odbc
+    name: feb_data
+    connection_string: Driver={PostgreSQL Unicode};Server=localhost;UID=${user};PWD=${pass};
+    query: SELECT * FROM temp_readings WHERE timestamp BETWEEN '2024-02-01' AND '2024-02-29'
+
+stages:
+  - name: jan_aggregated
+    query: >
+        SELECT
+          cast(timestamp as date) date,
+          location_id,
+          round(min(temperature_c),2) min_temp_c,
+          round(min(humidity),2) min_humidity,
+          round(max(temperature_c),2) max_temp_c,
+          round(max(humidity),2) max_humidity,
+          round(avg(temperature_c),2) avg_temp_c,
+          round(avg(humidity),2) avg_humidity
+        FROM jan_data
+        GROUP by 1,2
+        ORDER by 1 asc
+    # print 20 rows of the result for this query to stdout
+    show: 20 
+
+  - name: feb_aggregated
+    query: >
+        SELECT
+          cast(timestamp as date) date,
+          location_id,
+          round(min(temperature_c),2) min_temp_c,
+          round(min(humidity),2) min_humidity,
+          round(max(temperature_c),2) max_temp_c,
+          round(max(humidity),2) max_humidity,
+          round(avg(temperature_c),2) avg_temp_c,
+          round(avg(humidity),2) avg_humidity
+        FROM feb_data
+        GROUP by 1,2
+        ORDER by 1 asc
+    # print the entire result for this query to stdout
+    show: 0
+
+  - name: union
+    query: >
+      SELECT count(*) FROM jan_aggregated
+    show: 0


### PR DESCRIPTION
### Description
 
add odbc support for sources using arrow_odbc.
Users need to have `unixodbc` installed, the corresponding driver for the DB they are trying to access like mssql or postgres via [psqlodbc](https://github.com/postgresql-interfaces/psqlodbc) and then register the driver in the unixodbc manager config (`odbcinst.ini`).

The source can then be configured as following:
```yaml
sources:
  - type: Odbc
    name: jan_data
    connection_string: Driver={PostgreSQL Unicode};Server=localhost;UID=${user};PWD=${pass};
    query: SELECT * FROM temp_readings WHERE timestamp BETWEEN '2024-01-01' AND '2024-01-31'
```

The `Driver` property needs to be the name registered in the unixodbc manager config.
The query is used to fetch arrow data from the database before being processed by the Aqueduct pipeline.

The sink implementation will be in a separate PR